### PR TITLE
Rollback ALIGN macros

### DIFF
--- a/libs/hwui/utils/LinearAllocator.cpp
+++ b/libs/hwui/utils/LinearAllocator.cpp
@@ -48,8 +48,8 @@
 #define ALIGN_SZ (sizeof(int))
 #endif
 
-#define ALIGN(x) (((x) + ALIGN_SZ - 1 ) & ~(ALIGN_SZ - 1))
-#define ALIGN_PTR(p) ((void*)(ALIGN((size_t)(p))))
+#define ALIGN(x) ((x + ALIGN_SZ - 1 ) & ~(ALIGN_SZ - 1))
+#define ALIGN_PTR(p) ((void*)(ALIGN((size_t)p)))
 
 #if LOG_NDEBUG
 #define ADD_ALLOCATION(size)


### PR DESCRIPTION
In some weird cases, it is found that the new changes were causing issues. As an
example it caused WhatsApp crash when opening particular group chat where there
are many members.
Reverting the alignment solved that.
